### PR TITLE
feat(eslint-config): change eqeqeq rule's scope

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -67,7 +67,7 @@ module.exports = {
 		'one-var': ['error', 'never'],
 		'no-cond-assign': ['error', 'except-parens'],
 		'comma-dangle': ['error', 'always-multiline'],
-		eqeqeq: ['error', 'always'],
+		eqeqeq: ['error', 'always', { null: 'ignore' }],
 		'new-parens': ['error', 'always'],
 		'no-caller': 'error',
 		'no-constant-condition': 'error',


### PR DESCRIPTION
This commit avoids ESLint `eqeqeq` rule to prevent `==` and `!=` with
`null` and `undefined`.

Closes #7.